### PR TITLE
put in a "missing" step about node

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ spotty to do this programmatically.
 # Change directories
 cd app_examples/d7-app
 
+# Load all node dependencies
+npm install
+
 # Build all dependencies
 kbox build
 


### PR DESCRIPTION
basically added what I see as a missing step in the build instructions for npm install to happen before kbox build.
