### PR TITLE
Fix TypeError for kbox containers when kbox is down.

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -190,6 +190,10 @@ exports.down = function(attempts, callback) {
  * });
  */
 var list = exports.list = function(appName, callback) {
+  if (callback === undefined && typeof appName === 'function') {
+    callback = appName;
+    appName = null;
+  }
   verifyProviderIsReady(function(err) {
     if (err) {
       callback(err);


### PR DESCRIPTION
This ensures that the callback function within `exports.list` in `lib/engine.js` is indeed the intended callback function when the `appName` parameter is not provided. (It is described as optional). It resolves the TypeError that is thrown when running `kbox containers` while kbox is down:

```
/Users/pcoffey/Development/projects/kalabox/lib/engine.js:196
      callback(err);
      ^
TypeError: undefined is not a function
    at /Users/pcoffey/Development/projects/kalabox/lib/engine.js:196:7
    at /Users/pcoffey/Development/projects/kalabox/lib/engine.js:81:11
    at /Users/pcoffey/Development/projects/kalabox/lib/engine.js:64:9
    at /Users/pcoffey/Development/projects/kalabox/lib/engine/provider/b2d.js:180:7
    at /Users/pcoffey/Development/projects/kalabox/lib/engine/provider/b2d.js:109:11
    at EventEngine.emit (/Users/pcoffey/Development/projects/kalabox/lib/core/events.js:120:5)
    at Object.exports.emit (/Users/pcoffey/Development/projects/kalabox/lib/core/events.js:155:17)
    at /Users/pcoffey/Development/projects/kalabox/lib/engine/provider/b2d.js:108:16
    at /Users/pcoffey/Development/projects/kalabox/lib/engine/provider/b2d.js:35:7
    at /Users/pcoffey/Development/projects/kalabox/lib/util/shell.js:53:5
    at /Users/pcoffey/Development/projects/kalabox/node_modules/shelljs/src/exec.js:107:7
    at ChildProcess.exithandler (child_process.js:645:7)
    at ChildProcess.emit (events.js:98:17)
    at maybeClose (child_process.js:755:16)
    at Socket.<anonymous> (child_process.js:968:11)
    at Socket.emit (events.js:95:17)
```

Testing:
* Make sure that kbox is down (run `kbox down`).
* Run `kbox containers`.
* Ensure that you do not get the type error, but instead a "provider is NOT up" error.