### PR TITLE
Fixing bug where syncthing would always share a folder with the appConte...

### DIFF
--- a/lib/share/sync/sync.js
+++ b/lib/share/sync/sync.js
@@ -5,6 +5,7 @@ var rest = require('./syncRest.js');
 var Promise = require('bluebird');
 var _ = require('lodash');
 var core = require('../../core.js');
+var app = require('../../app.js');
 var spawn = require('child_process').spawn;
 var S = require('string');
 
@@ -187,8 +188,17 @@ Sync.prototype.addFolder = function(id, path, remoteSync, overrideOptions) {
 
 Sync.prototype.shareFolder = function(name, remoteSync) {
   var self = this;
-  return core.deps.call(function(appConfig) {
-    var localPath = appConfig.codeRoot;
+  return new Promise(function(fulfill, reject) {
+    app.get(name, function(err, app) {
+      if (err) {
+        reject(err);
+      } else {
+        fulfill(app);
+      }
+    });
+  })
+  .then(function(app) {
+    var localPath = app.config.codeRoot;
     var remotePath = '/' + name;
     return self.addFolder(name, localPath, remoteSync)
     .then(function() {


### PR DESCRIPTION
...xts code dir, even if there were two differnt apps being shared, with one of them not being the appContext.