### PR TITLE
Get rid of .git from global shareIgnores

### DIFF
--- a/lib/core/config.js
+++ b/lib/core/config.js
@@ -67,7 +67,6 @@ var DEFAULT_GLOBAL_CONFIG = {
     '.*DS_Store',
     '.DS_Store*',
     '._*',
-    '.git',
     '.sass-cache',
     'Icon',
     'Thumbs.db',


### PR DESCRIPTION
This should resolve the issues Tim, John, and I were having with using our local Git.