### PR TITLE
Added special case to error handling of bin/kbox.js for when a VError…

### DIFF
--- a/bin/kbox.js
+++ b/bin/kbox.js
@@ -38,7 +38,15 @@ function handleError(err) {
   if (argv.options.verbose) {
 
     // When verbose output, also print stack trace.
-    console.log(chalk.red(err.stack));
+    /*jshint camelcase: false */
+    /*jscs: disable */
+    if (err.jse_cause && err.jse_cause.stack) {
+      console.log(chalk.red(err.jse_cause.stack));
+    } else {
+      console.log(chalk.red(err.stack));
+    }
+    /*jshint camelcase: true */
+    /*jscs: enable */
 
   }
 


### PR DESCRIPTION
… error

has a inner stack trace that would normally be hidden from view. This will
provide more accurate errors, with exact modules and line number of the
offending error.