### PR TITLE
Fixing bug where updating kalabox then doing a provision causes the p…

### DIFF
--- a/lib/share.js
+++ b/lib/share.js
@@ -231,6 +231,20 @@ var getStartedLocalSync = function() {
 
 };
 
+var getRemoteSyncIfStarted = function() {
+
+  return getRemoteSync()
+  .then(function(remoteSync) {
+    return remoteSync.isUp()
+    .then(function(isUp) {
+      if (isUp) {
+        return remoteSync;
+      }
+    });
+  });
+
+};
+
 /*
  * Get a started instance of the remote syncthing.
  */
@@ -270,18 +284,14 @@ var getStartedRemoteSync = function() {
  */
 core.events.on('pre-down', function(done) {
 
-  var localSync = getStartedLocalSync();
-
-  var remoteSync = getStartedRemoteSync();
-
-  Promise.all([localSync, remoteSync])
-  .spread(function(localSync, remoteSync) {
-
-    return remoteSync.clear()
-    .then(function() {
-      return remoteSync.shutdown();
-    });
-
+  getRemoteSyncIfStarted()
+  .then(function(remoteSync) {
+    if (remoteSync) {
+      return remoteSync.clear()
+      .then(function() {
+        return remoteSync.shutdown();
+      });
+    }
   })
   .nodeify(done);
 


### PR DESCRIPTION
…re-down

event to be fired, then a failure occurs when the kalabox_syncthing container
can't access the kalabox_data container. Fix is to only try to reset syncthing
container if it's currently up and running, and to do nothing if it is not.