### PR TITLE
BUGFIX: Fixing regression that caused component.image.build value to …

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -77,7 +77,7 @@ var createComponent = function(app, name, componentSpec) {
       app.config.appRoot,
       app.config.srcRoot
     ].map(function(dir) {
-      return path.join(dir, component.image.srcRoot, 'Dockerfile');
+      return path.join(dir, 'dockerfiles', component.image.name, 'Dockerfile');
     });
     var rootPath = util.searchForPath(pathsToSearch);
     if (!rootPath) {


### PR DESCRIPTION
…always be

false because a guard that would override it was based upon a check for a file
with a badly built path. Path is now being built correctly and it solves the
issue.