### PR TITLE
Changed syncthing REST requests to always retry regardless of if it's an

### DIFF
--- a/lib/share/sync/syncRest.js
+++ b/lib/share/sync/syncRest.js
@@ -100,6 +100,9 @@ var requestWrapper = function(action, address, verb, data, opts) {
   // Merge options with default options.
   opts = _.extend(defaults, opts);
 
+  // Save for later.
+  var maxRetries = opts.counter;
+
   // Recursive function for requests.
   var rec = function(counter) {
 
@@ -110,18 +113,10 @@ var requestWrapper = function(action, address, verb, data, opts) {
     // Handle errors.
     .catch(function(err) {
 
-      // List of expected errors.
-      var expectedErrors = ['ECONNREFUSED', 'ECONNRESET', 'EPIPE'];
-
-      // Is this error expected?
-      var isExpectedError = _.any(expectedErrors, function(msg) {
-        return _.contains(err.message, msg);
-      });
-
       // @todo: @bcauldwell - Would also be nice to have a wrapped error
       // when max number of tries is reached.
 
-      if (counter > 0 && isExpectedError) {
+      if (counter > 0) {
 
         // This error sometimes happens so wait an interval and then retry.
         return Promise.delay(opts.interval * 1000)
@@ -132,7 +127,7 @@ var requestWrapper = function(action, address, verb, data, opts) {
       } else {
 
         // Rethrow error.
-        throw err;
+        throw new VError(err, 'Failed after max retries: %s', maxRetries);
 
       }
 
@@ -141,7 +136,7 @@ var requestWrapper = function(action, address, verb, data, opts) {
   };
 
   // Run recursive function.
-  return rec(opts.counter)
+  return rec(maxRetries)
   // Set a timeout.
   .timeout(opts.timeout * 1000)
   // Wrap timeout errors.


### PR DESCRIPTION
expected error or not. Also added a wrapped error message with the number
of max retries.
