### PR TITLE
Fix execAdmin by adding some checks

### DIFF
--- a/lib/util/shell.js
+++ b/lib/util/shell.js
@@ -48,7 +48,7 @@ var getAdminWrapper = function(cmd, options) {
       return 'osascript -e \'' + appleScript + '\'';
     }
     else {
-      if (options.password !== false) {
+      if (typeof options !== 'undefined' && options.password !== false) {
         return autoPass(cmd, options.password);
       }
       else {
@@ -67,7 +67,7 @@ var getAdminWrapper = function(cmd, options) {
       return 'pkexec --user root sudo sh -c \'' + cmd + '\'';
     }
     else {
-      if (options.password !== false) {
+      if (typeof options !== 'undefined' && options.password !== false) {
         return autoPass(cmd, options.password);
       }
       else {


### PR DESCRIPTION
`execAdmin()` only passes one argument to `getAdminWrapper()`, which means that `options` is always going to be undefined, causing an error when comparing for `options.password` to `false`.
