### PR TITLE
#949: Escape double quotes here instead of dns so impact is only on a…

### DIFF
--- a/lib/util/dns.js
+++ b/lib/util/dns.js
@@ -38,7 +38,7 @@ var dnsCmdWin32 = function(ip, data) {
 };
 
 /*
- * Helper command to build darwin dns command
+ * Helper command to build posix dns command
  */
 var dnsCmdPosix = function(ip, data, postIp) {
 
@@ -52,7 +52,7 @@ var dnsCmdPosix = function(ip, data, postIp) {
     data[0],
     '&&',
     'echo',
-    '\\"nameserver ' + ip + postIp + '\\"',
+    '"nameserver ' + ip + postIp + '"',
     '>>',
     esc(dnsFile)
   ].join(' ');

--- a/lib/util/shell.js
+++ b/lib/util/shell.js
@@ -48,7 +48,7 @@ var getGuiAdminWrapper = function(cmdString) {
     case 'darwin': return [
         'osascript',
         '-e',
-        '\'' + asWrap(cmdString) + '\''
+        '\'' + asWrap(cmdString.replace(/\"/g, '\\"')) + '\''
       ].join(' ');
   }
 


### PR DESCRIPTION
…dmin OSX

@rileysaurus 

i think we want to escape like this instead. if we dont then we end up getting quotes in /etc/resolver/kbox on linux and osx (cli)
