### PR TITLE
kalabox/kalabox#992 - mapping site environments in series instead of

### DIFF
--- a/plugins/kalabox-pantheon/index.js
+++ b/plugins/kalabox-pantheon/index.js
@@ -121,7 +121,7 @@ module.exports = function(kbox) {
               site.environments.sort();
               return site;
             });
-          });
+          }, {concurrency: 1});
         });
       })
       .wrap('Error getting sites.');


### PR DESCRIPTION
parallel to avoid interference between sites that was causing all sites
for a provider to have the same envs.
