### PR TITLE
fixes to desktop entry for all known DEs & add Category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,5 @@ v0.12.0-alpha4
 * Updated our development process with new contribution guidelines and standards [#1236](https://github.com/kalabox/kalabox/issues/1236)
 
 #### Bug fixes
+
+* Added all [registered Desktop Environments](https://standards.freedesktop.org/menu-spec/latest/apb.html) so that Kalabox has the best chance of showing up in the app menu and [appended to the Category list](https://standards.freedesktop.org/menu-spec/latest/ar01s03.html) "Development" [#1272](https://github.com/kalabox/kalabox/issues/1272)

--- a/linux/desktop/kalabox-ui.desktop
+++ b/linux/desktop/kalabox-ui.desktop
@@ -2,7 +2,7 @@
 Name=Kalabox
 Comment=Fask local dev
 Keywords=development;
-OnlyShowIn=GNOME;KDE;LXDE;MATE;Razor;ROX;TDE;Unity;XFCE;EDE;Cinnamon;Old
+OnlyShowIn=GNOME;KDE;LXDE;MATE;Razor;ROX;TDE;Unity;XFCE;EDE;Cinnamon;Old;
 Path=/usr/share/kalabox/gui/Kalabox
 Exec=/usr/share/kalabox/gui/Kalabox/Kalabox
 Icon=/usr/share/kalabox/kalabox.png

--- a/linux/desktop/kalabox-ui.desktop
+++ b/linux/desktop/kalabox-ui.desktop
@@ -2,11 +2,11 @@
 Name=Kalabox
 Comment=Fask local dev
 Keywords=development;
-OnlyShowIn=GNOME;Unity;
+OnlyShowIn=GNOME;KDE;LXDE;MATE;Razor;ROX;TDE;Unity;XFCE;EDE;Cinnamon;Old
 Path=/usr/share/kalabox/gui/Kalabox
 Exec=/usr/share/kalabox/gui/Kalabox/Kalabox
 Icon=/usr/share/kalabox/kalabox.png
 StartupNotify=true
 Terminal=false
 Type=Application
-Categories=Utility;
+Categories=Development;Utility;


### PR DESCRIPTION
@pirog 
Added all [registered Desktop Environments](https://standards.freedesktop.org/menu-spec/latest/apb.html) so that Kalabox has the best chance of showing up in the app menu and [appended to the Category list](https://standards.freedesktop.org/menu-spec/latest/ar01s03.html) "Development" [#1272](https://github.com/kalabox/kalabox/issues/1272)

---

Thank you so much for contributing code to Kalabox!

We will get to your PR as soon as we can but in the meantime you might want to
check to make sure you have done the following. **The more boxes you can check
the easier it will be for us to merge in your changes with confidence**
- [ N/A ] My code passes relevant CI status checks
- [ N/A ] My code includes a test ([see here](https://github.com/kalabox/kalabox/blob/HEAD/CONTRIBUTING.md))
- [ YES ] My code includes an update to `CHANGELOG.md` ([see here](https://github.com/kalabox/kalabox/blob/HEAD/CHANGELOG.md))
- [ N/A ] My code includes documentation updates if relevant.
- [ YES ] I have pinged @pirog when I think my code is ready for prime time.

If you are unclear about any of the above please add comments below so we can
improve our process.
