### PR TITLE
Update kalabox.desktop

### DIFF
--- a/installer/linux/desktop/kalabox.desktop
+++ b/installer/linux/desktop/kalabox.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Kalabox
-Comment=Fask local dev
+Comment=Fast local dev
 Keywords=development;
 OnlyShowIn=GNOME;KDE;LXDE;MATE;Razor;ROX;TDE;Unity;XFCE;EDE;Cinnamon;Old;
 Path=/usr/share/kalabox/


### PR DESCRIPTION
fix typo in Linux desktop entry description
