### PR TITLE
#1593: Relax criteria for a site to show as ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+v2.0.0
+======
+
+* Relaxed criteria for a site to "Be ready". [#1593](https://github.com/kalabox/kalabox/issues/1593)
+
 v0.13.0-rc.3
 ============
 

--- a/plugins/kalabox-core/lib/events.js
+++ b/plugins/kalabox-core/lib/events.js
@@ -7,6 +7,7 @@ module.exports = function(kbox) {
 
   // Npm modules
   var rest = require('restler');
+  var _ = require('lodash');
 
   // Kalabox modules
   var Promise = kbox.Promise;
@@ -45,9 +46,21 @@ module.exports = function(kbox) {
 
         // Throw an error on fail/error
         .on('fail', function(data, response) {
+
+          // Get the codes and define codes that should indicate the site
+          // is not ready yet
           var code = response.statusCode;
-          log.debug(format('%s not yet ready with code %s.', site, code));
-          reject(new Error(response));
+          var waitCodes = [400, 502];
+
+          if (_.includes(waitCodes, code)) {
+            log.debug(format('%s not yet ready with code %s.', site, code));
+            reject(new Error(response));
+          }
+          else {
+            log.debug(format('%s is now ready.', site));
+            fulfill(data);
+          }
+
         }).on('error', reject);
 
       });


### PR DESCRIPTION
Thank you so much for contributing code to Kalabox!

We will get to your PR as soon as we can but in the meantime you might want to
check to make sure you have done the following. **The more boxes you can check
the easier it will be for us to merge in your changes with confidence**
- [x] My code passes relevant CI status checks
- [ ] My code includes a test ([see here](http://docs.kalabox.io/developers/testing))
- [x] My code includes an update to `CHANGELOG.md` ([see here](https://github.com/kalabox/kalabox/blob/HEAD/CHANGELOG.md))
- [x] My code includes documentation updates if relevant.
- [x] I have pinged @pirog when I think my code is ready for prime time.

If you are unclear about any of the above please add comments below so we can
improve our process.
