### PR TITLE
Change OS X to macOS and other typo fixes

### DIFF
--- a/docs/developers/config.md
+++ b/docs/developers/config.md
@@ -5,7 +5,7 @@ The Kalabox config system is highly flexible and allows you to configure a few t
 
   * The default domain suffix.
   * The plugins it should load.
-  * The plugin which contains the engine implementation.
+  * The plugin that contains the engine implementation.
 
 kalabox.yaml
 -------------
@@ -14,7 +14,7 @@ This file specifies the core configuration options for Kalabox. If you wanted to
 
   1. The default `kalabox.yml`. If you've installed Kalabox from source this will be in the source root.
   2. The `kalabox.yml` inside of the `sysConfRoot`. For example `/usr/share/kalabox` on Linux.
-  3. The `kalabox.yml` inside of the `userConfRoot`. For examples `~/.kalabox/` on OSX.
+  3. The `kalabox.yml` inside of the `userConfRoot`. For examples `~/.kalabox/` on macOS.
 
 !!! attention "Where are `sysConfRoot` and `userConfRoot`?"
     Run `kbox config` to find the location of these directories as they can be different.

--- a/docs/developers/plugins.md
+++ b/docs/developers/plugins.md
@@ -16,7 +16,7 @@ Kalabox has an advanced plugin system that allows developers to add and extend K
 Installation
 ------------
 
-In order to get you plugin working with Kalabox you need to do two things:
+To get the plugin working with Kalabox do two things:
 
   1. [Override config](./config) to include your plugin's name.
   2. Place your plugin into the correct location. (see below)
@@ -25,7 +25,7 @@ Kalabox looks for plugins in either the `node_modules` or `plugins` folder in th
 
   1. The source directory.
   2. Inside of the `sysConfRoot`. For example `/usr/share/kalabox` on Linux.
-  3. Inside of the `userConfRoot`. For examples `~/.kalabox/` on OSX.
+  3. Inside of the `userConfRoot`. For example `~/.kalabox/` on macOS.
 
 !!! attention "Where are `sysConfRoot` and `userConfRoot`?"
     Run `kbox config` to find the location of these directories as they can be different.
@@ -35,7 +35,7 @@ Kalabox looks for plugins in either the `node_modules` or `plugins` folder in th
 Kalabox ships with two external plugins by default: ["Pantheon on Kalabox"](http://github.com/kalabox/kalabox-app-pantheon) and ["PHP on Kalabox"](http://github.com/kalabox/kalabox-app-php). These are installed into your `sysConfRoot` by the Kalabox installer along with a `kalabox.yml` override file. Let's say we want to do development on the "Pantheon on Kalabox" plugin.
 
 ```bash
-# Go into the `usrConfRoot`, Assuming OSX and `~/.kalabox` for this example
+# Go into the `usrConfRoot`; assuming macOS and `~/.kalabox` for this example
 cd ~/.kalabox
 
 # Create a plugins folder

--- a/docs/general/engine.md
+++ b/docs/general/engine.md
@@ -4,19 +4,19 @@ The Engine
 
 The Kalabox engine is what powers the container magix of Kalabox. At a high level, the engine is just a slightly customized Docker daemon. This customization exists so we do not collide with any of the user's existing Docker daemons.
 
-There are a few differences on how this works between Linux and OSX/Windows which are detailed in sections below.
+There are a few differences on how this works between Linux and macOS/Windows, which are detailed in sections below.
 
-Engine for OSX/Win
-------------------
+Engine for macOS/Win
+--------------------
 
-In order to spin up Docker containers you need a recent version of the Linux kernel. As you might imagine, Windows and OSX do not contain the Linux kernel. As such Kalabox will spin up a small virtual machine during install to do this. The general pieces we use to do this are as follows:
+To spin up Docker containers you need a recent version of the Linux kernel. As you might imagine, Windows and macOS do not contain the Linux kernel. As such Kalabox will spin up a small virtual machine during install to do this. The general pieces we use to do this are as follows:
 
 * **VirtualBox** - We use Oracle's [VirtualBox](http://virtualbox.org) as the virtualization engine. After you install Kalabox you should be able to open up VirtualBox and see a VM called "Kalabox2".
 * **Docker Machine** - We use [Docker Machine](https://docs.docker.com/machine/) to handle the management of the Kalabox engine.
 * **Boot2Docker** - We use [Boot2Docker](https://github.com/boot2docker/boot2docker) as the actual VM image. Boot2Docker is a small ISO built on top of [Tiny Core Linux](http://tinycorelinux.net/).
 
-!!! attention "Docker Beta for OSX/Windows"
-    As soon as the Docker Beta for [Windows](https://docs.docker.com/docker-for-windows/) and [OSX](https://docs.docker.com/docker-for-mac/) becomes stable and has performant file sharing we intend to switch our backend over to that. This will greatly reduce our dependency chain, allowing for the removal of `docker-machine` and VirtualBox.
+!!! attention "Docker Beta for macOS/Windows"
+    As soon as the Docker Beta for [Windows](https://docs.docker.com/docker-for-windows/) and [macOS](https://docs.docker.com/docker-for-mac/) becomes stable and has performant file sharing we intend to switch our backend over to that. This will greatly reduce our dependency chain, allowing for the removal of `docker-machine` and VirtualBox.
 
 ### Turning the engine on or off
 
@@ -42,7 +42,7 @@ If you feel like the engine is **OUT OF CONTROL** and you want to try to manuall
 
 ### Accessing the Engine directly
 
-#### OSX
+#### macOS
 
 ```bash
 # You might want to consider adding this to your PATH variable
@@ -69,11 +69,11 @@ set DOCKER_MACHINE="C:\Program Files\Kalabox\bin\docker-machine-exe"
 Engine for Linux
 ----------------
 
-On Linux the Kalabox engine runs a custom Docker daemon via the [Docker Engine](https://www.Docker.com/products/docker-engine). This is an unsecure daemon which listens on `10.13.37.100:2375`.
+On Linux the Kalabox engine runs a custom Docker daemon via the [Docker Engine](https://www.Docker.com/products/docker-engine). This is an insecure daemon that listens on `10.13.37.100:2375`.
 
 ### Turning the engine on or off
 
-The Kalabox engine runs as a service. We support the `SysV`, `Upstart` and `systemd` init systems. By default the Kalabox service will launch when you boot your system but you can control it similar to OSX/Windows.
+The Kalabox engine runs as a service. We support the `SysV`, `Upstart` and `systemd` init systems. By default the Kalabox service will launch when you boot your system but you can control it similar to macOS/Windows.
 
 ```bash
 # Turn the Kalabox engine off

--- a/docs/general/sysreq.md
+++ b/docs/general/sysreq.md
@@ -8,7 +8,7 @@ Operating System
 
 Currently Kalabox is compatible with...
 
-  * Mac OS X 10.10+
+  * macOS 10.10+
   * Windows 7+
   * Debian 7/Ubuntu 14.04+
   * Fedora 23+
@@ -23,6 +23,6 @@ Hardware Requirements
   * 4GB RAM
   * Modern processor (~last 3 years)
 
-!!! note "Storage Requirements for OSX/Windows Virtual Disk"
+!!! note "Storage Requirements for macOS/Windows Virtual Disk"
     Note that Kalabox itself does not take up 20GB of hard drive space, but reserves that space for your sites in a virtual disk.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ With Kalabox you can...
 
   * Easily mimic your production environment on local.
   * Setup, develop, pull and deploy your sites super fast.
-  * Standardize your teams dev environments and tools on OSX, Windows and Linux.
+  * Standardize your team's dev environments and tools on macOS, Windows and Linux.
   * Easily customize or extend tooling, deployment options and basically any other functionality.
   * Free yourself from the tyranny of inferior local development products.
 
@@ -16,7 +16,7 @@ Learn more and get general Kalabox information by visting [our docs](http://docs
 Getting Started
 ---------------
 
-Kalabox ships as native installer packages for Windows, OSX, Debian and Fedora. Officially supported versions are available on our [releases page](https://github.com/kalabox/kalabox/releases). To get informed of new Kalabox releases and project updates we encourage you to [sign up for our newsletter](http://www.kalabox.io/).
+Kalabox ships as native installer packages for Windows, macOS, Debian and Fedora. Officially supported versions are available on our [releases page](https://github.com/kalabox/kalabox/releases). To get informed of new Kalabox releases and project updates we encourage you to [sign up for our newsletter](http://www.kalabox.io/).
 
 Once you've [installed Kalabox](http://docs.kalabox.io/en/stable/users/install/#installation) you should have...
 
@@ -77,7 +77,7 @@ an official release is rolled.
   * **Windows** - [http://installer.kalabox.io/kalabox-latest-dev.exe](http://installer.kalabox.io/kalabox-latest-dev.exe)
   * **Debian** - [http://installer.kalabox.io/kalabox-latest-dev.deb](http://installer.kalabox.io/kalabox-latest-dev.deb)
   * **Fedora** - [http://installer.kalabox.io/kalabox-latest-dev.rpm](http://installer.kalabox.io/kalabox-latest-dev.rpm)
-  * **MacOSX** - [http://installer.kalabox.io/kalabox-latest-dev.dmg](http://installer.kalabox.io/kalabox-latest-dev.dmg)
+  * **macOS** - [http://installer.kalabox.io/kalabox-latest-dev.dmg](http://installer.kalabox.io/kalabox-latest-dev.dmg)
 
 **NOTE:** Releases can take some time to build after we merge in commits. For that reason you might want to check the time of the last commit and if it is within a few hours you might want to hold off a bit before trying the new latest release.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -9,7 +9,7 @@ Install Logs
 If you have a failed installation, you should be able to find logs in the following locations...
 
 * **Windows** - `%TEMP%\Setup Log**.txt`
-* **MacOSX** - `/var/log/install.log`
+* **macOS** - `/var/log/install.log`
 * **Linux** - Differs per system but check common `apt` or `dnf/yum` logs
 
 Runtime Logs
@@ -17,7 +17,7 @@ Runtime Logs
 
 If you encounter an error during runtime, check out the runtime log at...
 
-  * **OSX/LINUX** - `~/.kalabox/logs/kalabox.log`
+  * **macOS/LINUX** - `~/.kalabox/logs/kalabox.log`
   * **Windows** - `C:\Users\{ME}\.kalabox\logs\kalabox.log`
 
 !!! tip "Pro Tip: Use verbose or debug mode!""
@@ -29,7 +29,7 @@ Docker Logs
 One of the best ways to troubleshoot an issue is to get access to the Kalabox Engine and start hacking around.
 
 !!! attention "Make sure you are ready to run Docker commands on the engine"
-    Follow the instructions for [OSX/Windows](./general/engine/#engine-for-osxwin) or [Linux](./general/engine/#engine-for-linux)
+    Follow the instructions for [macOS/Windows](./general/engine/#engine-for-osxwin) or [Linux](./general/engine/#engine-for-linux)
 
 **Some basic Docker commands**
 

--- a/docs/users/cli.md
+++ b/docs/users/cli.md
@@ -4,9 +4,9 @@ Kalabox CLI
 The Kalabox CLI is accessible via your terminal by typing `kbox` at the prompt, which will display the list of commands you can run. Kalabox operates in one of two contexts:
 
   * **Global** - This is any directory that does not contain a Kalabox app.
-  * **App** - This is any directory which does contain an app.
+  * **App** - This is any directory that contains an app.
 
-The context will determine the list of commands you can run. If you have app context then the commands you run will apply to the app. In the example above Kalabox is running in an app context. You will see that Kalabox will group the commands into seperate contexts for you.
+The context will determine the list of commands you can run. If you have an app context then the commands you run will apply to the app. In the example above Kalabox is running in an app context. You will see that Kalabox will group the commands into separate contexts for you.
 
 If you are in a different app or global context you can easily run a command against another app using the `kbox <APPNAME> command` syntax.
 
@@ -48,7 +48,7 @@ Options:
   -h, --help     Display help message.                                 [boolean]
   -v, --verbose  Use verbose output.                                   [boolean]
   -d, --debug    Use debug output.                                     [boolean]
-  -y, --yes      Automatically answer affirmitive                      [boolean]
+  -y, --yes      Automatically answer affirmative                      [boolean]
 ```
 
 ```bash
@@ -66,7 +66,7 @@ kbox app2 destroy
 down
 ----
 
-Deactivates the Kalabox engine by shutting down the Kalabox daemon on Linux or the Kalabox2 VM on OSX/Windows. **This will stop all running apps.**
+Deactivates the Kalabox engine by shutting down the Kalabox daemon on Linux or the Kalabox2 VM on macOS/Windows. **This will stop all running apps.**
 
 `kbox down`
 
@@ -128,7 +128,7 @@ kbox rebuild -- -v
 !!! danger "Be careful using this command! It rebuilds EVERYTHING"
     If you have application data or code stored in a web or database container, this data will be lost as well unless you have properly volumed it or written a plugin to ensure the data sensitive container is not included in the rebuild.
 
-    For example, the [Pantheon](http://github.com/kalabox/kalabox-app-pantheon) and [PHP](http://github.com/kalabox/kalabox-app-php) plugins store all application data in a `data` container which is preserved through a rebuild.
+    For example, the [Pantheon](http://github.com/kalabox/kalabox-app-pantheon) and [PHP](http://github.com/kalabox/kalabox-app-php) plugins store all application data in a `data` container that is preserved through a rebuild.
 
 restart
 -------
@@ -221,7 +221,7 @@ Options:
 up
 --
 
-Activates the Kalabox engine by turning on the Kalabox daemon on Linux or the Kalabox2 VM on OSX/Windows. **This will get you in a state so you can create new or start existing apps.**
+Activates the Kalabox engine by turning on the Kalabox daemon on Linux or the Kalabox2 VM on macOS/Windows. **This will get you in a state so you can create new or start existing apps.**
 
 `kbox up`
 
@@ -249,7 +249,7 @@ Options:
 Additional Commands
 -------------------
 
-Please consult the [configuration](./config.md) page to learn more about adding your own custom commmands. Custom commands allow you to do some of the following things.
+Please consult the [configuration](./config.md) page to learn more about adding your own custom commands. Custom commands allow you to do some of the following things.
 
   1. Pull down sites from a hosting provider.
   2. Add additional tools to your app like `npm`, `grunt` or `gulp`.

--- a/docs/users/config.md
+++ b/docs/users/config.md
@@ -1,14 +1,14 @@
 Configuration
 =============
 
-Kalabox has a sophisticated plugin system that allows users to extend core functionality and provide easy configuration options around many things. Here we will detail some of the configuration options provides by core Kalabox plugins.
+Kalabox has a sophisticated plugin system that allows users to extend core functionality and provide easy configuration options around many things. Here we will detail some of the configuration options provided by core Kalabox plugins.
 
 Sharing
 -------
 
 Kalabox seeks to mitigate the **HARDEST PROBLEM** in VM-based local development: quickly sharing files from your host machine into the VM while maintaining fast page loads. This is a longstanding issue and no project has a perfect solution; for a longer discussion on filesharing, see the [Advanced file sharing topics](#advanced-file-sharing-topics) section below.
 
-With Kalabox, you can easily enable file sharing by adding a `sharing` object to the `pluginconfig` of your app's `kalabox.yml` file. If you are on Mac OSX or Windows then sharing does have [some limitations](#advanced-file-sharing-topics) so we've also provided a few easy ways to both ignore specific kinds of files and share specific directories. If you have a particularly large codebase we **highly recommend** you take advantage of the `paths` and `ignore` options to speed up your sync.
+With Kalabox, you can easily enable file sharing by adding a `sharing` object to the `pluginconfig` of your app's `kalabox.yml` file. If you are on macOS or Windows then sharing does have [some limitations](#advanced-file-sharing-topics) so we've also provided a few easy ways to both ignore specific kinds of files and share specific directories. If you have a particularly large codebase we **highly recommend** you take advantage of the `paths` and `ignore` options to speed up your sync.
 
 We already try to do some basic optimization for you by ignoring the following:
 
@@ -103,11 +103,11 @@ When it comes to file sharing in Virtual Machine-based local development environ
 
 Solutions like `vbfs` or `nfs`, which mount files over the network, provide instantaneous changes. They also require the remote machine to "check in" to see if there are any changes to a file before it is read or written. For a site or app with a few files this is no big deal. However, when you have an app using a modern CMS like Drupal with thousands of files, this "checking in" can substantially slow a page load from less than a second to 5, 10, 40 or never seconds, depending on the load.
 
-If you are a sitebuilder who works through the UI instead of directly in code, these solutions can burn a lot of time.
+If you are a site builder who works through the UI instead of directly in code, these solutions can burn a lot of time.
 
 **Fast page loads**
 
-Solutions like `rsync` or `syncthing` will try to keep two directories synced. This lowers the speed that your code change propogates to seconds and can often burn a lot of resources on your machine but it will preserve "native" speed page loads.
+Solutions like `rsync` or `syncthing` will try to keep two directories synced. This reduces the speed that your code change propagates to just seconds and can often burn a lot of resources on your machine but it will preserve "native" speed page loads.
 
 If you are someone who is writing and changing code a lot these solutions can burn a lot of time.
 
@@ -119,17 +119,17 @@ The sharing process works like this
 
   1. Your code changes are instantaneously synced to the VM by VirtualBox's `vbfs`
   2. Your local `vbfs` shared local code root and container webroot are mounted into the same `unison` container
-  3. We run a `unison` container for each app that scans for and then propogates those changes every second.
+  3. We run a `unison` container for each app that scans for and then propagates those changes every second.
 
 !!! attention "We do we scan instead of watch?"
     We cannot use native filesystem events in this model due to [a won't fix bug](https://www.virtualbox.org/ticket/10660) in VirtualBox.
 
 #### The Downside
 
-While this produces `nfs` speed file change propogation along with "native" page loads, the speed of propagation does slow as you increase the amount of files you are scanning. Luckily, we've provided a few ways for you to optimize your sync.
+While this produces `nfs` speed file change propagation along with "native" page loads, the speed of propagation does slow as you increase the amount of files you are scanning. Luckily, we've provided a few ways for you to optimize your sync.
 #### The Roadmap Forward
 
-We **really, really hope** that the above is a stop-gap solution. Docker is currently working on "native" filesharing for both OSX and Windows. Once those are complete and perform better than what we have we will switch our sharing over to use them. You can track the progress of that issue over here:
+We **really, really hope** that the above is a stop-gap solution. Docker is currently working on "native" file sharing for both macOS and Windows. Once those are complete and perform better than what we have we will switch our sharing over to use them. You can track the progress of that issue over here:
 
  * [https://forums.docker.com/t/file-access-in-mounted-volumes-extremely-slow-cpu-bound/8076/108](https://forums.docker.com/t/file-access-in-mounted-volumes-extremely-slow-cpu-bound/8076/108)
 
@@ -238,7 +238,7 @@ You can easily add additional development tools to any Kalabox app using our bak
 Tooling works by installing and associating additional Docker containers to your app. These containers should contain the development commands you wish to run and should be set up to mount relevant local assets like `ssh keys`, config or code. While well constructed tooling containers should feel like "natively" running the same commands there are a few things that can be different. Here are some general guidelines to help you construct good tooling containers:
 
   1. Mount your webroot into the tooling container so you have access to your code.
-  2. Use a custom entrypoint script to correctly map local to container permissions.
+  2. Use a custom entry point script to correctly map local to container permissions.
   3. Mount your binaries as volumes so they can be shared with containers.
   4. Set the container's working directory so that it matches the users local location.
   5. Set any config in relevant environmental variables if possible
@@ -404,16 +404,16 @@ You should now be able to run `kbox` and see the following commands listed...
   * `kbox php`
   * `kbox composer`
 
-These commands should all work like they normally do with the exception of `mysql` which will drop you directly to the `mysql` prompt.
+These commands should all work like they normally do with the exception of `mysql`, which will drop you directly to the `mysql` prompt.
 
 ```bash
-# Drop into a myqsl shell connected to my app's database container
+# Drop into a mysql shell connected to my app's database container
 kbox mysql
 
 # Run an arbitrary piece of php
 kbox php -e "phpinfo();"
 
-# Flush my drupal caches
+# Flush my Drupal caches
 kbox drush cc all
 
 # Check the composer version

--- a/docs/users/install.md
+++ b/docs/users/install.md
@@ -9,8 +9,8 @@ Preinstall Checks
 3. Verify that you have administrative access to your machine.
 4. If you have previously installed Kalabox and are attempting to install a new  version check out our [update guide](./updating.md) before continuing.
 
-Mac OSX
--------
+macOS
+-----
 
 ### Installation Steps
 
@@ -79,7 +79,7 @@ sudo rpm -i kalabox.deb
 Common Installation Issues
 --------------------------
 
-### OSX
+### macOS
 
 1. [Duplicate host only adapter](./../troubleshooting/#resolving-duplicate-host-only-adapters)
 

--- a/docs/users/started.md
+++ b/docs/users/started.md
@@ -7,12 +7,12 @@
 Getting Started
 ===============
 
-Now that you've [succesfully installed](./install.md) Kalabox you can start creating your own apps. Kalabox apps are completely isolated development environments which means on a high level they contain the following things:
+Now that you've [successfully installed](./install.md) Kalabox you can start creating your own apps. Kalabox apps are completely isolated development environments. At a high level they contain the following things:
 
   1. Metadata about the containers and services your application needs to run.
   2. Metadata about the tooling your application needs for development.
   3. High level configuration such as name, service exposure, file sharing, etc.
-  4. Your applications codebase.
+  4. Your application’s codebase.
 
 !!! note "Apps are mutually exclusive"
     This architecture means that everything you need to run and develop your app is contained within the app itself. That means you can blow away `app1` without it having any impact on the containers and tools you are using on `app2`.
@@ -24,8 +24,8 @@ Kalabox apps can be quite simple or massively complex. For example, a Kalabox ap
 
 A Kalabox app at it's smallest requires only two files:
 
-  1. A `kalabox.yml` file which contains the high level configuration for your app.
-  2. A `kalabox-compose.yml` file which contains the services your app needs to run.
+  1. A `kalabox.yml` file that contains the high level configuration for your app.
+  2. A `kalabox-compose.yml` file that contains the services your app needs to run.
 
 !!! tip "Kalabox uses Docker Compose"
     The `kalabox-compose` file is simply a [Docker Compose](https://docs.docker.com/compose/compose-file/) file.
@@ -48,7 +48,7 @@ Now that you've started up the app you should have...
   2. A webroot with the default `nginx` index.html inside your app in the `code` directory.
 
 !!! tip "File sharing"
-    Everything in your apps `code` directory should be synced to the webserver. Try editing `index.html` and refreshing your site to see all the magix.
+    Everything in your apps `code` directory should be synced to the web server. Try editing `index.html` and refreshing your site to see all the magix.
 
 Now let examine your app's directory structure and files.
 
@@ -97,6 +97,6 @@ web:
 ```
 
 !!! tip "PRO TIP: Level up your `kalabox-compose.yml`"
-    You can use variables found in `kbox env` when constructing your `kalabox-compose.yml` such as `$KALABOX_APP_HOSTNAME`. This can give you a lot of power and flexibilty when crafting your app.
+    You can use variables found in `kbox env` when constructing your `kalabox-compose.yml` such as `$KALABOX_APP_HOSTNAME`. This can give you a lot of power and flexibility when crafting your app.
 
 

--- a/docs/users/uninstall.md
+++ b/docs/users/uninstall.md
@@ -6,8 +6,8 @@ Preuninstall Checks
 
 1. Make sure you have closed the Kalabox GUI and terminated any running Kalabox process
 
-Mac OSX
--------
+macOS
+-----
 
 1. Mount the DMG you downloaded to install Kalabox. Visit [the Kalabox release page](https://github.com/kalabox/kalabox/releases) if you no longer have the DMG
 2. Double click on the `uninstall.command` script
@@ -49,7 +49,7 @@ Manually Uninstalling Kalabox
 
 There are still some bugs with our native uninstallers. If you feel like your Kalabox uninstallation has not completed successfully please review the following things have been removed and then try the uninstaller again.
 
-### Kalabox engine has been removed successfully on OSX/Windows
+### Kalabox engine has been removed successfully on macOS/Windows
 
 1. Open up VirtualBox and manually remove the Kalabox2 VM, including all its files if it shows up.
 2. Remove `~/.docker/machine/machines/Kalabox2/` if it exists
@@ -69,7 +69,7 @@ ps aux | grep 10.13.37.100
 sudo kill PID
 ```
 
-### Remove Kalabox directories on Linux/OSX
+### Remove Kalabox directories on Linux/macOS
 
 ```bash
 # Linux
@@ -77,7 +77,7 @@ sudo service kalabox stop
 sudo rm -rf /usr/share/kalabox
 sudo rm -f /etc/resolver/kbox
 
-# OSX
+# macOS
 sudo rm -rf /Applications/Kalabox.app
 sudo rm -f /etc/resolver/kbox
 ```

--- a/docs/users/updating.md
+++ b/docs/users/updating.md
@@ -34,12 +34,12 @@ Normal updating if fairly simple.
 2. Follow the [normal installation steps](./install.md) with the new version.
 
 !!! note "Older apps will not be updated!!!"
-    If you created apps with a previous version of Kalabox these apps will not be updated. In order to also update your apps we recommend you destroy and recreate those apps.
+    If you created apps with a previous version of Kalabox these apps will not be updated. Also, to update your apps we recommend you destroy and recreate those apps.
 
 Purge Updating
 --------------
 
-In order to update to a Kalabox that has breaking changes you will want to purge the old and install the new one. The easiest way to do this is:
+To update to a Kalabox that has breaking changes purge the old installation and install the new one. The easiest way to do this is:
 
 1. Destroy all the apps you have (see [backing up older apps](#backing-up-older-appps))
 2. Shutdown the Kalabox GUI and/or kill any running Kalabox CLI process.


### PR DESCRIPTION
OS X has changed names and there were other typos throughout the docs

Closes #1602 
